### PR TITLE
Update xmake.lua

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -63,8 +63,8 @@ function shared_module(targetName, version, ...)
     shared_lib(targetName, version, ...)
     before_build(function(target)
         os.exec("lua BuildTools/ModuleInfoGen.lua ".."meta "..target:scriptdir().." ./")
-        for i = 1, #target._INFO._INFO.includedirs do
-            --print(target._INFO._INFO.includedirs[i])
+        for _, includedir in ipairs(target:get("includedirs")) do
+            --print(includedir)
         end
     end)
 end


### PR DESCRIPTION
这里只是对现有xmake.lua写法的改进建议，不用merge此pr。。


>  os.exec("lua BuildTools/ModuleInfoGen.lua ".."meta "..target:scriptdir().." ./")

另外，执行lua脚本不建议这么用，通过内置import更方便的导入使用，比如：

```lua
import("BuildTools.ModuleInfoGen")
ModuleInfoGen()
```

ModuleInfoGen.lua 里面定义了 main 主入口，就可以 ModuleInfoGen(...)调用了

```lua
import("json")
function main (...)
    json.decode(...)
    
    -- 另外文件操作不用额外lfs，内置接口都可以很方便完成，路径模式匹配规则跟add_files方式一致：
    for _, dir in ipairs(os.dirs("xxx/dir/*")) do
         print(dir)
    end
end
```

你可以看下import接口的使用，它是require的扩展，支持require的同时还支持更多方便的特性。

https://xmake.io/#/zh-cn/manual/builtin_modules?id=import

另外xmake提供了很多内置模块来快速处理os, io, file,等，也有很多内置的扩展模块 可以用比如socket, net, http, archive等，可以看下 https://xmake.io/#/zh-cn/manual/extension_modules

如果有些模块不知道xmake是否提供，可以先不急着使用require导入第三方的，因为这样工程的迁移维护还要依赖lua环境和依赖包，尽量使用xmake内置提供的接口，不知道的可以先issues到xmake里面问下。


>         local attr = lfs.attributes(ff)
>        JsonFile = ff
>       JsonFileModify = attr.modification

这个可以直接用`os.mtime(jsonfile)`代替

https://github.com/SaeruHikari/SakuraEngine/blob/443c5c2dcd25e83bf2e69756530754f41a277a40/BuildTools/ModuleInfoGen.lua#L30-L44

这个可以直接简化为：

```lua
io.writefile("filepath.h", [[
//A header file genereate by Sakura J2H tool
//Contains the infomation of a module of Sakura Engine
...
]])
```